### PR TITLE
Updated readme to reflect AIO nodes without ruby in path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Related links:
 On AIO nodes, the call sequence is as simple as:
 
 ```sh
-./add-cli-auth-to-certificate /etc/puppetlabs/puppet/ssl/certs/$(hostname -f).pem
+/opt/puppetlabs/puppet/bin/ruby ./add-cli-auth-to-certificate /etc/puppetlabs/puppet/ssl/certs/$(hostname -f).pem
 ```
 
 If the `ssldir` is not the AIO default one, it's possible to explicitly provide the path to the ca certificate and key:

--- a/add-cli-auth-to-certificate
+++ b/add-cli-auth-to-certificate
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env /opt/puppetlabs/puppet/bin/ruby
 
 require 'fileutils'
 require 'openssl'

--- a/add-cli-auth-to-certificate
+++ b/add-cli-auth-to-certificate
@@ -1,4 +1,4 @@
-#!/usr/bin/env /opt/puppetlabs/puppet/bin/ruby
+#!/usr/bin/env ruby
 
 require 'fileutils'
 require 'openssl'


### PR DESCRIPTION
First of all, thanks for this handy script!

But I ran in to an issue. When trying to run this script on a puppetserver, it didn't work because by default there is no ruby installed on a puppetserver. There is a ruby provided by puppetlabs itself, but it is not used by the script.

I don't like installing a ruby on the puppetserver if a correct working one is provided by puppetlabs upon installation, so i've updated the script to use that ruby. I've also tested in on my own environments and it worked fine without installing an additional ruby on the server.